### PR TITLE
refactor: DB 종류에 따라 클리너가 자동 적용되고, jakarta 의존성 없이도 @Transactional 검사가 된다

### DIFF
--- a/src/main/java/banlife/NoTransactionExtension.java
+++ b/src/main/java/banlife/NoTransactionExtension.java
@@ -6,10 +6,11 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
-import org.springframework.core.annotation.AnnotatedElementUtils;
-import org.springframework.test.context.TestContextAnnotationUtils;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ClassUtils;
+
+import java.lang.reflect.AnnotatedElement;
 
 @Slf4j
 public class NoTransactionExtension implements BeforeEachCallback {
@@ -23,22 +24,49 @@ public class NoTransactionExtension implements BeforeEachCallback {
     }
 
     private static void validateTransactionalAnnotationExists(ExtensionContext extensionContext) {
-        if (TestContextAnnotationUtils.hasAnnotation(extensionContext.getRequiredTestClass(), Transactional.class) ||
-                TestContextAnnotationUtils.hasAnnotation(extensionContext.getRequiredTestClass(), jakarta.transaction.Transactional.class)) {
-            Assertions.fail("테스트 클래스에 @Transactional 또는 @jakarta.transaction.Transactional 어노테이션이 존재합니다.");
+        var testClass = extensionContext.getRequiredTestClass();
+        var testMethod = extensionContext.getRequiredTestMethod();
+
+        if (testClass.isAnnotationPresent(Transactional.class) ||
+                testMethod.isAnnotationPresent(Transactional.class)) {
+            Assertions.fail("@Transactional 어노테이션이 테스트 클래스나 메서드에 존재합니다.");
         }
 
-        if (AnnotatedElementUtils.hasAnnotation(extensionContext.getRequiredTestMethod(), Transactional.class) ||
-                AnnotatedElementUtils.hasAnnotation(extensionContext.getRequiredTestMethod(), jakarta.transaction.Transactional.class)) {
-            Assertions.fail("테스트 메서드에 @Transactional 또는 @jakarta.transaction.Transactional 어노테이션이 존재합니다.");
+        var jakartaTxClassName = "jakarta.transaction.Transactional";
+        if (ClassUtils.isPresent(jakartaTxClassName, NoTransactionExtension.class.getClassLoader())) {
+            try {
+                var jakartaTxClass = Class.forName(jakartaTxClassName);
+
+                if (hasAnnotationByName(testClass, jakartaTxClass) || hasAnnotationByName(testMethod, jakartaTxClass)) {
+                    Assertions.fail("@jakarta.transaction.Transactional 어노테이션이 테스트 클래스나 메서드에 존재합니다.");
+                }
+
+            } catch (ClassNotFoundException e) {
+                log.debug("jakarta.transaction.Transactional 클래스가 없어서 어노테이션 검사를 생략합니다.");
+            } catch (Exception e) {
+                log.warn("jakarta.transaction 어노테이션 검사 중 예외 발생", e);
+            }
         }
+    }
+
+    private static boolean hasAnnotationByName(AnnotatedElement element, Class<?> annotationClass) {
+        try {
+            for (var annotation : element.getAnnotations()) {
+                if (annotation != null && annotation.annotationType().getName().equals(annotationClass.getName())) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("어노테이션 검사 중 예외 발생 (element: {})", element, e);
+        }
+        return false;
     }
 
     private static void cleanDatabase(ApplicationContext applicationContext) {
         try {
             DatabaseCleaner.clear(applicationContext);
         } catch (NoSuchBeanDefinitionException e) {
-            log.debug("Database Cleaning not supported.");
+            log.debug("DatabaseCleaner Bean이 없어 DB 초기화를 생략합니다.");
         }
     }
 }

--- a/src/main/java/banlife/cleaner/DatabaseCleanerStrategy.java
+++ b/src/main/java/banlife/cleaner/DatabaseCleanerStrategy.java
@@ -1,0 +1,5 @@
+package banlife.cleaner;
+
+public interface DatabaseCleanerStrategy {
+    void clean();
+}

--- a/src/main/java/banlife/cleaner/DatabaseType.java
+++ b/src/main/java/banlife/cleaner/DatabaseType.java
@@ -1,0 +1,46 @@
+package banlife.cleaner;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.Locale;
+
+public enum DatabaseType {
+
+    H2 {
+        @Override
+        public boolean matches(String productName) {
+            return "H2".equalsIgnoreCase(productName);
+        }
+
+        @Override
+        public DatabaseCleanerStrategy getCleaner(JdbcTemplate jdbcTemplate) {
+            return new H2Cleaner(jdbcTemplate);
+        }
+    },
+
+    MYSQL {
+        @Override
+        public boolean matches(String productName) {
+            return "MySQL".equalsIgnoreCase(productName);
+        }
+
+        @Override
+        public DatabaseCleanerStrategy getCleaner(JdbcTemplate jdbcTemplate) {
+            return new MySqlCleaner(jdbcTemplate);
+        }
+    };
+
+    public abstract boolean matches(String productName);
+
+    public abstract DatabaseCleanerStrategy getCleaner(JdbcTemplate jdbcTemplate);
+
+    public static DatabaseType fromProductName(String productName) {
+        var normalized = productName.toLowerCase(Locale.ROOT);
+        for (var type : values()) {
+            if (type.matches(normalized)) {
+                return type;
+            }
+        }
+        throw new UnsupportedOperationException("지원하지 않는 데이터베이스입니다: " + productName);
+    }
+}

--- a/src/main/java/banlife/cleaner/H2Cleaner.java
+++ b/src/main/java/banlife/cleaner/H2Cleaner.java
@@ -1,0 +1,26 @@
+package banlife.cleaner;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+
+public class H2Cleaner implements DatabaseCleanerStrategy {
+    private final JdbcTemplate jdbcTemplate;
+
+    public H2Cleaner(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void clean() {
+        jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY FALSE");
+        for (var tableName : findTableNames()) {
+            jdbcTemplate.execute("DELETE FROM " + tableName);
+        }
+        jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY TRUE");
+    }
+
+    private List<String> findTableNames() {
+        return jdbcTemplate.query("SHOW TABLES", (rs, rowNum) -> rs.getString(1));
+    }
+}

--- a/src/main/java/banlife/cleaner/MySqlCleaner.java
+++ b/src/main/java/banlife/cleaner/MySqlCleaner.java
@@ -1,0 +1,26 @@
+package banlife.cleaner;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+
+public class MySqlCleaner implements DatabaseCleanerStrategy {
+    private final JdbcTemplate jdbcTemplate;
+
+    public MySqlCleaner(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void clean() {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS=0");
+        for (var tableName : findTableNames()) {
+            jdbcTemplate.execute("DELETE FROM " + tableName);
+        }
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS=1");
+    }
+
+    private List<String> findTableNames() {
+        return jdbcTemplate.queryForList("SHOW TABLES", String.class);
+    }
+}


### PR DESCRIPTION
- NoTransactionExtension에서 jakarta 의존성 제거 및 어노테이션 검사 방식 개선
- EntityManager 제거, JdbcTemplate 기반으로 DB 초기화 로직 단순화
- DatabaseType enum 도입으로 DB 종류별 전략 생성 책임을 위임